### PR TITLE
Docker-compose sem mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,23 @@ services:
     #     networks:
     #         compose-networks:
     #             ipv4_address: 172.28.1.7
+    
+    db:
+        image: mysql:5.7
+        restart: always
+        environment:
+          MYSQL_DATABASE: "mysql_docker"
+          MYSQL_USER: "user"
+          MYSQL_PASSWORD: "root"
+          MYSQL_ROOT_PASSWORD: "root"
+        ports:
+          - "3306:3306"
+        expose:
+          - "3306"
+        volumes:
+          - my-db:/var/lib/mysql
+    volumes:
+      my-db:
 
 networks: 
     compose-networks:


### PR DESCRIPTION
Cara, tava precisando do Mysql no compose, como o seu estava sem eu acrescentei. Verifica se vai funcionar em conjunto com os outros... :)